### PR TITLE
Fix compilation for GCC 4.6.2

### DIFF
--- a/pngwolf.cxx
+++ b/pngwolf.cxx
@@ -52,6 +52,10 @@
 #include <map>
 #include <bitset>
 
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t)-1)
+#endif
+
 #ifdef _MSC_VER
 #pragma warning(push, 4)
 #pragma warning(disable: 4996)
@@ -168,7 +172,7 @@ public:
   std::vector<char> original_unfiltered;
 
   // 
-  std::map<PngFilter, std::vector<char>> flt_singles;
+  std::map<PngFilter, std::vector<char> > flt_singles;
 
   //
   std::map<uint32_t, size_t> invis_colors;


### PR DESCRIPTION
pngwolf fails to compile on my system (Arch Linux, 64 bit) with the default compiler (GCC 4.6.2 20111125 (prerelease)) due to the following errors:
- error: '>>' should be '> >' within a nested template argument list (line 171)
- error: 'SIZE_MAX' was not declared in this scope (various lines)

I don't really know C++, but I managed to come up with the attached patch after a bit of googling. Feel free to incorporate it if you deem it useful.
